### PR TITLE
Support GHC 9.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,21 +8,17 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210222
+# version: 0.13.20211030
 #
-# REGENDATA ("0.11.20210222",["github","cabal.project"])
+# REGENDATA ("0.13.20211030",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  - push
+  - pull_request
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
@@ -30,63 +26,133 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 9.0.1
+          - compiler: ghc-9.2.1
+            compilerKind: ghc
+            compilerVersion: 9.2.1
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.10.4
+          - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.2.2
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.0.2
+          - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.10.3
+          - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.8.4
+          - compiler: ghc-7.10.3
+            compilerKind: ghc
+            compilerVersion: 7.10.3
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.6.3
+          - compiler: ghc-7.8.4
+            compilerKind: ghc
+            compilerVersion: 7.8.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.4.2
+          - compiler: ghc-7.6.3
+            compilerKind: ghc
+            compilerVersion: 7.6.3
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.2.2
+          - compiler: ghc-7.4.2
+            compilerKind: ghc
+            compilerVersion: 7.4.2
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 7.0.4
+          - compiler: ghc-7.2.2
+            compilerKind: ghc
+            compilerVersion: 7.2.2
+            setup-method: hvr-ppa
+            allow-failure: false
+          - compiler: ghc-7.0.4
+            compilerKind: ghc
+            compilerVersion: 7.0.4
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+          fi
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -150,13 +216,14 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_cpphs="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/cpphs-[0-9.]*')"
-          echo "PKGDIR_cpphs=${PKGDIR_cpphs}" >> $GITHUB_ENV
+          echo "PKGDIR_cpphs=${PKGDIR_cpphs}" >> "$GITHUB_ENV"
           PKGDIR_HaXml="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/HaXml-[0-9.]*')"
-          echo "PKGDIR_HaXml=${PKGDIR_HaXml}" >> $GITHUB_ENV
+          echo "PKGDIR_HaXml=${PKGDIR_HaXml}" >> "$GITHUB_ENV"
           PKGDIR_hscolour="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/hscolour-[0-9.]*')"
-          echo "PKGDIR_hscolour=${PKGDIR_hscolour}" >> $GITHUB_ENV
+          echo "PKGDIR_hscolour=${PKGDIR_hscolour}" >> "$GITHUB_ENV"
           PKGDIR_polyparse="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/polyparse-[0-9.]*')"
-          echo "PKGDIR_polyparse=${PKGDIR_polyparse}" >> $GITHUB_ENV
+          echo "PKGDIR_polyparse=${PKGDIR_polyparse}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_cpphs}" >> cabal.project
@@ -183,9 +250,9 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all

--- a/HaXml-1.25.4/HaXml.cabal
+++ b/HaXml-1.25.4/HaXml.cabal
@@ -21,8 +21,9 @@ build-type:     Simple
 extra-source-files: Changelog.md
 
 tested-with:
-  GHC ==9.0.1
-   || ==8.10.4
+  GHC ==9.2.1
+   || ==9.0.1
+   || ==8.10.7
    || ==8.8.4
    || ==8.6.5
    || ==8.4.4
@@ -89,8 +90,8 @@ library
         Text.XML.HaXml.Schema.Schema
   hs-source-dirs: src
   build-depends:
-    base       >= 4.3.1.0  && < 4.16,
-    bytestring >= 0.9.1.10 && < 0.11,
+    base       >= 4.3.1.0  && < 4.17,
+    bytestring >= 0.9.1.10 && < 0.12,
     containers >= 0.4.0.0  && <0.7,
     filepath   >= 1.2.0.0  && <1.5,
     pretty     >= 1.0.1.2  && <1.2,

--- a/cpphs-1.20.9/cpphs.cabal
+++ b/cpphs-1.20.9/cpphs.cabal
@@ -24,8 +24,9 @@ Build-type: Simple
 Extra-Source-Files: README, LICENCE-GPL, LICENCE-commercial, CHANGELOG, docs/cpphs.1, docs/index.html
 
 tested-with:
-  ghc ==9.0.1
-   || ==8.10.4
+  ghc ==9.2.1
+   || ==9.0.1
+   || ==8.10.7
    || ==8.8.4
    || ==8.6.5
    || ==8.4.4
@@ -53,7 +54,7 @@ Library
       Hs-Source-Dirs: . old
 
     else
-      Build-Depends: time >=1.5 && <1.11
+      Build-Depends: time >=1.5 && <1.13
       Hs-Source-Dirs: . new
 
     Exposed-Modules:
@@ -82,7 +83,7 @@ Executable cpphs
       Hs-Source-Dirs: . old
 
     else
-      Build-Depends: time >=1.5 && <1.11
+      Build-Depends: time >=1.5 && <1.13
       Hs-Source-Dirs: . new
 
     Other-Modules:

--- a/hscolour-1.24.4/hscolour.cabal
+++ b/hscolour-1.24.4/hscolour.cabal
@@ -9,7 +9,7 @@ License-file: LICENCE-LGPL
 Synopsis: Colourise Haskell code.
 Description:
   hscolour is a small Haskell script to colourise Haskell code. It currently
-  has six output formats: 
+  has six output formats:
   ANSI terminal codes (optionally XTerm-256colour codes),
   HTML 3.2 with <font> tags,
   HTML 4.01 with CSS,
@@ -39,7 +39,7 @@ tested-with:
 
 Library
   Build-depends: base < 10, containers
-  Exposed-Modules: 
+  Exposed-Modules:
     Language.Haskell.HsColour
     Language.Haskell.HsColour.ANSI
     Language.Haskell.HsColour.Anchors
@@ -57,7 +57,7 @@ Library
     Language.Haskell.HsColour.Output
     Language.Haskell.HsColour.TTY
   --ghc-options: -O -W
-  Extensions: 
+  Extensions:
 
 
 Executable HsColour

--- a/hscolour-1.24.4/hscolour.cabal
+++ b/hscolour-1.24.4/hscolour.cabal
@@ -23,8 +23,9 @@ Data-files: hscolour.css, data/rgb24-example-.hscolour
 Cabal-version: >=1.8
 
 tested-with:
-  GHC ==9.0.1
-   || ==8.10.4
+  GHC ==9.2.1
+   || ==9.0.1
+   || ==8.10.7
    || ==8.8.4
    || ==8.6.5
    || ==8.4.4

--- a/polyparse-1.12/polyparse.cabal
+++ b/polyparse-1.12/polyparse.cabal
@@ -25,8 +25,9 @@ cabal-version:  >=1.8
 extra-source-files: Changelog.md
 
 tested-with:
-  GHC ==9.0.1
-   || ==8.10.4
+  GHC ==9.2.1
+   || ==9.0.1
+   || ==8.10.7
    || ==8.8.4
    || ==8.6.5
    || ==8.4.4
@@ -50,7 +51,7 @@ source-repository this
 
 library
   hs-source-dirs:       src
-  build-depends:        base >= 4.3.1.0 && < 4.16
+  build-depends:        base >= 4.3.1.0 && < 4.17
 
   if !impl(ghc >= 8.0)
      build-depends: fail == 4.9.*
@@ -70,7 +71,7 @@ library
         Text.ParserCombinators.Poly.Lex,
         Text.Parse
   if impl(ghc)
-    build-depends:      bytestring >= 0.9.1.0 && < 0.11
+    build-depends:      bytestring >= 0.9.1.0 && < 0.12
     build-depends:      text >= 1.2.3.0 && <1.3
     exposed-modules:
         Text.ParserCombinators.Poly.ByteString


### PR DESCRIPTION
Relax upper bounds (supporting GHC 9.2), include 9.2 in CI.

Successful CI run at: https://github.com/andreasabel/malcolm-wallace-universe/actions/runs/1409034526

Let me know if you want me to also implement these revisions on hackage.

UPDATE: 
- blocking https://github.com/haskell-infra/hackage-trustees/issues/320