### PR TITLE
WIP: cpphs dogfood

### DIFF
--- a/.github/workflows/ghcup.yml
+++ b/.github/workflows/ghcup.yml
@@ -1,0 +1,46 @@
+name: ghcup
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ghcup:
+    name: ${{ matrix.os }} ghcup ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        ghc: [9.6.1, 9.4.5, 9.2.7, 9.0.2, 8.10.7]
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install GHC
+      run: ghcup install ghc ${{ matrix.ghc }} --set
+
+    - name: Update cabal index
+      run: cabal update
+
+    - name: Configure
+      run: cabal configure --enable-tests --enable-benchmarks
+
+    - name: Build dependencies
+      run: cabal build all --dependencies-only
+
+    - name: Build
+      run: cabal build all
+
+    - name: Run tests
+      run: cabal test all

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -279,6 +279,9 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: tests
+        run: |
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_cpphs} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -162,7 +162,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -281,7 +281,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_cpphs} || false

--- a/.github/workflows/haskell-setup.yml
+++ b/.github/workflows/haskell-setup.yml
@@ -1,0 +1,46 @@
+name: ghcup
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ghcup:
+    name: ${{ matrix.os }} windows ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        ghc: [9.6.1, 9.4.4, 9.2.7, 9.0.2, 8.10.7]
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install GHC
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-update: true
+
+    - name: Configure
+      run: cabal configure --enable-tests --enable-benchmarks
+
+    - name: Build dependencies
+      run: cabal build all --dependencies-only
+
+    - name: Build
+      run: cabal build all
+
+    - name: Run tests
+      run: cabal test all

--- a/.github/workflows/haskell-setup.yml
+++ b/.github/workflows/haskell-setup.yml
@@ -1,4 +1,4 @@
-name: ghcup
+name: haskell-setup
 on:
   push:
     branches:
@@ -14,8 +14,8 @@ defaults:
     shell: bash
 
 jobs:
-  ghcup:
-    name: ${{ matrix.os }} windows ${{ matrix.ghc }}
+  haskell-setup:
+    name: ${{ matrix.os }} haskell-setup ${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -27,7 +27,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Install GHC
+    - name: Install GHC with haskell/actions/setup
       uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/stack-ghcup.yml
+++ b/.github/workflows/stack-ghcup.yml
@@ -1,0 +1,52 @@
+name: stack
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack:
+    name: ${{ matrix.os }} stack ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+          ghc: 9.4.5
+          resolver: nightly-2023-04-30
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install GHC and stack with haskell/actions/setup
+      uses: haskell/actions/setup@wz1000-ghcup
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
+        cabal-update: false
+
+    - name: Create stack.yaml
+      run: |
+        echo "resolver: ${{ matrix.resolver }}" > stack.yaml
+        echo "packages: [cpphs-1.20.9, hscolour-1.24.4, polyparse-1.12]" >> stack.yaml
+
+    - name: Build dependencies
+      run: stack build --dependencies-only
+
+    - name: Build
+      run: stack build
+
+    - name: Run tests
+      run: stack test

--- a/.github/workflows/stack-no-global.yml
+++ b/.github/workflows/stack-no-global.yml
@@ -1,0 +1,50 @@
+name: stack-no-global
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack-no-global:
+    name: ${{ matrix.os }} resolver ${{ matrix.resolver }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        resolver: [nightly-2023-04-30, lts-20.19, lts-19.33, lts-18.28]
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install GHC and stack with haskell/actions/setup
+      uses: haskell/actions/setup@v2
+      with:
+        stack-no-global: true
+        enable-stack: true
+        cabal-update: false
+
+    - name: Create stack.yaml
+      run: |
+        echo "resolver: ${{ matrix.resolver }}" > stack.yaml
+        echo "packages: [cpphs-1.20.9, hscolour-1.24.4, polyparse-1.12]" >> stack.yaml
+
+    - name: Build dependencies
+      run: stack build --dependencies-only
+
+    - name: Build
+      run: stack build
+
+    - name: Run tests
+      run: stack test

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,61 @@
+name: stack
+on:
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack:
+    name: ${{ matrix.os }} stack ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - os: windows-latest
+          ghc: 9.4.4
+          resolver: nightly-2023-04-24
+        - os: windows-latest
+          ghc: 9.2.7
+          resolver: lts-20.19
+        - os: windows-latest
+          ghc: 9.0.2
+          resolver: lts-19.33
+        - os: windows-latest
+          ghc: 8.10.7
+          resolver: lts-18.28
+
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install GHC and stack with haskell/actions/setup
+      uses: haskell/actions/setup@v2
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
+        cabal-update: false
+
+    - name: Create stack.yaml
+      run: |
+        echo "resolver: ${{ matrix.resolver }}" > stack.yaml
+        echo "packages: [cpphs-1.20.9, hscolour-1.24.4, polyparse-1.12]" >> stack.yaml
+
+    - name: Build dependencies
+      run: stack build --dependencies-only
+
+    - name: Build
+      run: stack build
+
+    - name: Run tests
+      run: stack test

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,4 @@
+branches: master ci*
+
+-- test for cpphs uses gitrev which wants base >= 4.6
+tests: >= 7.6

--- a/cpphs-1.20.9/cpphs.cabal
+++ b/cpphs-1.20.9/cpphs.cabal
@@ -103,6 +103,22 @@ Executable cpphs
         Language.Preprocessor.Cpphs.Tokenise
         TimeCompat
 
+test-suite test
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+    hs-source-dirs: test
+    build-depends:
+        base
+      , cpphs
+      , gitrev >= 1.3.1 && < 2
+    build-tool-depends: cpphs:cpphs
+    ghc-options:        -pgmP cpphs -optP --cpp
+
+    other-modules:
+      Version
+      VersionCommit
+      Paths_cpphs
+
 Source-Repository head
     Type:     git
     Location: https://github.com/hackage-trustees/malcolm-wallace-universe

--- a/cpphs-1.20.9/test/Test.hs
+++ b/cpphs-1.20.9/test/Test.hs
@@ -1,0 +1,6 @@
+import Version
+import VersionCommit
+
+main = do
+    putStrLn version
+    putStrLn versionWithCommitInfo

--- a/cpphs-1.20.9/test/Version.hs
+++ b/cpphs-1.20.9/test/Version.hs
@@ -1,0 +1,15 @@
+module Version
+  ( version
+  ) where
+
+import Data.List ( intercalate )
+import Data.Version ( Version(versionBranch) )
+
+import qualified Paths_cpphs as Paths
+
+-- | The version of Agda.
+
+version :: String
+version = intercalate "." $ map show $
+            versionBranch Paths.version
+

--- a/cpphs-1.20.9/test/VersionCommit.hs
+++ b/cpphs-1.20.9/test/VersionCommit.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ >= 900
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+#endif
+
+module VersionCommit where
+
+import Development.GitRev
+
+import Version
+
+versionWithCommitInfo :: String
+versionWithCommitInfo = version ++ maybe "" ("-" ++) commitInfo
+
+-- | Information about current git commit, generated at compile time
+commitInfo :: Maybe String
+commitInfo
+  | hash == "UNKNOWN" = Nothing
+  | otherwise         = Just $ abbrev hash ++ dirty
+  where
+    hash = $(gitHash)
+
+    -- Check if any tracked files have uncommitted changes
+    dirty | $(gitDirtyTracked) = "-dirty"
+          | otherwise          = ""
+
+    -- Abbreviate a commit hash while keeping it unambiguous
+    abbrev = take 7


### PR DESCRIPTION
This PR adds a number of workflows to test `cpphs` under Windows, using some `TemplateHaskell`.
Test extracted from Agda code base, motivated by:
- https://github.com/commercialhaskell/stack/issues/6111
- https://github.com/haskell/ghcup-hs/issues/823

Succeeds for Ubuntu w/ cabal ([haskell-ci.yml](https://github.com/hackage-trustees/malcolm-wallace-universe/actions/runs/4845313883)) and these Windows configurations:
1. cabal w/ GHC 8.10 ([ghcup.yml](https://github.com/hackage-trustees/malcolm-wallace-universe/actions/runs/4845313884) & [haskell-setup.yml](https://github.com/hackage-trustees/malcolm-wallace-universe/actions/runs/4845313885))
2. stack w/ GHC >= 9 ([stack.yml](https://github.com/hackage-trustees/malcolm-wallace-universe/actions/runs/4845313889) & [stack-no-global.yml](https://github.com/hackage-trustees/malcolm-wallace-universe/actions/runs/4845313893))

Fails for:
1. cabal w/ GHC >= 9
2. stack w/ GHC 8.10