### PR TITLE
bytestring 0.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,20 +8,14 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.1
+# version: 0.16.4
 #
-# REGENDATA ("0.16.1",["github","cabal.project"])
+# REGENDATA ("0.16.4",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
-  push:
-    branches:
-      - master
-      - ci*
-  pull_request:
-    branches:
-      - master
-      - ci*
+  - push
+  - pull_request
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -34,9 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.5
@@ -44,9 +38,9 @@ jobs:
             compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/cpphs-1.20.9/cpphs.cabal
+++ b/cpphs-1.20.9/cpphs.cabal
@@ -25,9 +25,9 @@ Build-type: Simple
 Extra-Source-Files: README, LICENCE-GPL, LICENCE-commercial, CHANGELOG, docs/cpphs.1, docs/index.html
 
 tested-with:
-  GHC ==9.6.1
+  GHC ==9.6.2
    || ==9.4.5
-   || ==9.2.7
+   || ==9.2.8
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4

--- a/hscolour-1.24.4/hscolour.cabal
+++ b/hscolour-1.24.4/hscolour.cabal
@@ -23,9 +23,9 @@ Data-files: hscolour.css, data/rgb24-example-.hscolour
 Cabal-version: >=1.8
 
 tested-with:
-  GHC ==9.6.1
+  GHC ==9.6.2
    || ==9.4.5
-   || ==9.2.7
+   || ==9.2.8
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4

--- a/polyparse-1.12/polyparse.cabal
+++ b/polyparse-1.12/polyparse.cabal
@@ -1,6 +1,6 @@
 name:           polyparse
 version:        1.13
-x-revision:     6
+x-revision:     7
 license:        LGPL
 license-files:   COPYRIGHT, LICENCE-LGPL, LICENCE-commercial
 copyright:      (c) 2006-2016 Malcolm Wallace
@@ -73,7 +73,7 @@ library
         Text.ParserCombinators.Poly.Lex,
         Text.Parse
   if impl(ghc)
-    build-depends:      bytestring >= 0.9.1.0 && < 0.12
+    build-depends:      bytestring >= 0.9.1.0 && < 0.13
     build-depends:      text >= 1.2.3.0 && <1.3 || >=2.0 && <2.1
     exposed-modules:
         Text.ParserCombinators.Poly.ByteString

--- a/polyparse-1.12/polyparse.cabal
+++ b/polyparse-1.12/polyparse.cabal
@@ -25,9 +25,9 @@ cabal-version:  >=1.8
 extra-source-files: Changelog.md
 
 tested-with:
-  GHC ==9.6.1
+  GHC ==9.6.2
    || ==9.4.5
-   || ==9.2.7
+   || ==9.2.8
    || ==9.0.2
    || ==8.10.7
    || ==8.8.4


### PR DESCRIPTION
- Bump Haskell CI to latest GHCs: 9.6.2 and 9.2.8
- polyparse-1.13~6: allow bytestring-0.12
