### PR TITLE
Insert spaces around function composition.

### DIFF
--- a/cpphs-1.20.9/Language/Preprocessor/Cpphs/MacroPass.hs
+++ b/cpphs-1.20.9/Language/Preprocessor/Cpphs/MacroPass.hs
@@ -167,7 +167,7 @@ macroProcess pr layout lang st (Ident p x: ws) =
                             Just (args,ws') ->
                                 if length args /= length (arguments hd) then
                                      emit x $ macroProcess pr layout lang st ws
-                                else do args' <- mapM (fmap (concat.onlyRights)
+                                else do args' <- mapM (fmap (concat . onlyRights)
                                                        . macroProcess pr layout
                                                                         lang st)
                                                       args

--- a/cpphs-1.20.9/Language/Preprocessor/Cpphs/SymTab.hs
+++ b/cpphs-1.20.9/Language/Preprocessor/Cpphs/SymTab.hs
@@ -36,11 +36,11 @@ flattenST :: SymTab v -> [v]
 
 emptyST           = itgen maxHash []
 insertST (s,v) ss = itiap (hash s) ((s,v):)    ss id
-deleteST  s    ss = itiap (hash s) (filter ((/=s).fst)) ss id
-lookupST  s    ss = let vs = filter ((==s).fst) ((itind (hash s)) ss)
+deleteST  s    ss = itiap (hash s) (filter ((/=s) . fst)) ss id
+lookupST  s    ss = let vs = filter ((==s) . fst) ((itind (hash s)) ss)
                     in if null vs then Nothing
                        else (Just . snd . head) vs
-definedST s    ss = let vs = filter ((==s).fst) ((itind (hash s)) ss)
+definedST s    ss = let vs = filter ((==s) . fst) ((itind (hash s)) ss)
                     in (not . null) vs
 flattenST      ss = itfold (map snd) (++) ss
 

--- a/polyparse-1.12/src/Text/Parse.hs
+++ b/polyparse-1.12/src/Text/Parse.hs
@@ -237,7 +237,7 @@ parseInt :: (Integral a) => String ->
 parseInt base radix isDigit digitToInt =
                  do cs <- many1 (satisfy isDigit)
                     return (foldl1 (\n d-> n*radix+d)
-                                   (map (fromIntegral.digitToInt) cs))
+                                   (map (fromIntegral . digitToInt) cs))
                  `adjustErr` (++("\nexpected one or more "++base++" digits"))
 parseDec, parseOct, parseHex :: (Integral a) => TextParser a
 parseDec = parseInt "decimal" 10 Char.isDigit    Char.digitToInt
@@ -255,7 +255,7 @@ parseFloat = do ds   <- many1 (satisfy isDigit)
                   . (% 1) .  (\ (Right x) -> x) . fst
                   . runParser parseDec ) (ds++frac)
              `onFail`
-             do w <- many (satisfy (not.isSpace))
+             do w <- many (satisfy (not . isSpace))
                 case map toLower w of
                   "nan"      -> return (0/0)
                   "infinity" -> return (1/0)
@@ -441,7 +441,7 @@ instance Parse a => Parse (Maybe a) where
             parens (p>9)   (do { isWord "Just"
                                ; fmap Just $ parsePrec 10
                                      `adjustErrBad` ("but within Just, "++) })
-            `adjustErr` (("expected a Maybe (Just or Nothing)\n"++).indent 2)
+            `adjustErr` (("expected a Maybe (Just or Nothing)\n"++) . indent 2)
 
 instance (Parse a, Parse b) => Parse (Either a b) where
     parsePrec p =

--- a/polyparse-1.12/src/Text/Parse/ByteString.hs
+++ b/polyparse-1.12/src/Text/Parse/ByteString.hs
@@ -271,7 +271,7 @@ parseInt :: (Integral a) => String ->
 parseInt base radix isDigit digitToInt =
                  do cs <- many1 (satisfy isDigit)
                     return (foldl1 (\n d-> n*radix+d)
-                                   (map (fromIntegral.digitToInt) cs))
+                                   (map (fromIntegral . digitToInt) cs))
                  `adjustErr` (++("\nexpected one or more "++base++" digits"))
 
 -- | Parse a decimal, octal, or hexadecimal (unsigned) Integral numeric literal.


### PR DESCRIPTION
Using foo.bar for function composition does not work with the RecordDotSyntax extension, so insert some spaces.